### PR TITLE
aws-sdkのaccess_key_idを削除

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -28,7 +28,7 @@ module Refile
   class S3
     extend Refile::BackendMacros
 
-    attr_reader :access_key_id, :max_size
+    attr_reader, :max_size
 
     # Sets up an S3 backend
     #
@@ -45,7 +45,6 @@ module Refile
       @s3 = Aws::S3::Resource.new @s3_options
       credentials = @s3.client.config.credentials
       raise S3CredentialsError unless credentials
-      @access_key_id = credentials.access_key_id
       @bucket_name = bucket
       @bucket = @s3.bucket @bucket_name
       @hasher = hasher
@@ -60,7 +59,7 @@ module Refile
     verify_uploadable def upload(uploadable)
       id = @hasher.hash(uploadable)
 
-      if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3) and uploadable.backend.access_key_id == access_key_id
+      if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3)
         object(id).copy_from(copy_source: [@bucket_name, uploadable.backend.object(uploadable.id).key].join("/"))
       else
         object(id).put(body: uploadable, content_length: uploadable.size)


### PR DESCRIPTION
aws_sdkのアップデートで、削除されるメソッドがあるが、
そのメソッドがrefile-s3で使われている。
Carelyの実装では使われていないため、該当のメソッドを使用しているところを削除する

該当エラー
```
[ec2-user@carely-www-clinicdemo-01-apne1a current]$ RAILS_ENV=qa bundle exec rake db:seed_fu FILTER=healthcheck_clinicdemo > /tmp/result.txt
DEPRECATION WARNING: called deprecated method `access_key_id' of an Aws::CredentialProvider, use #credentials instead
/var/rails/www/shared/bundle/ruby/2.6.0/bundler/gems/refile-s3-60572a111be2/lib/refile/s3.rb:48:in `initialize'
```

access_key_idメソッドがaws_sdk 2.2.0で削除されるらしい
https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/CredentialProvider.html#credentials-instance_method